### PR TITLE
第一次执行addViewControllerAtIndex需指定self.currentViewController = viewCont…

### DIFF
--- a/WMPageController/WMPageController.m
+++ b/WMPageController/WMPageController.m
@@ -230,7 +230,7 @@
     [viewController didMoveToParentViewController:self];
     [self.scrollView addSubview:viewController.view];
     [self.displayVC setObject:viewController forKey:@(index)];
-    
+    self.currentViewController = viewController;
     [self backToPositionIfNeeded:viewController atIndex:index];
 }
 


### PR DESCRIPTION
目前	第一次执行addViewControllerAtIndex并未指定self.currentViewController＝viewController；导致viewDidLayoutSubviews后，currentindex  view 的frame 无法更新，以至于无法显示，。