### PR TITLE
加入禁止缓存的策略

### DIFF
--- a/WMPageController/WMPageController.h
+++ b/WMPageController/WMPageController.h
@@ -19,7 +19,8 @@
     and continue to grow back after a while.
     If recieved too much times, the cache policy will stay at 'LowMemory' and don't grow back any more.
  */
-typedef NS_ENUM(NSUInteger, WMPageControllerCachePolicy) {
+typedef NS_ENUM(NSInteger, WMPageControllerCachePolicy) {
+    WMPageControllerCachePolicyDisable   = -1,  // Disable Cache
     WMPageControllerCachePolicyNoLimit   = 0,  // No limit
     WMPageControllerCachePolicyLowMemory = 1,  // Low Memory but may block when scroll
     WMPageControllerCachePolicyBalanced  = 3,  // Balanced ↑ and ↓

--- a/WMPageController/WMPageController.m
+++ b/WMPageController/WMPageController.m
@@ -116,7 +116,9 @@ static NSInteger const kWMControllerCountUndefined = -1;
 
 - (void)setCachePolicy:(WMPageControllerCachePolicy)cachePolicy {
     _cachePolicy = cachePolicy;
-    self.memCache.countLimit = _cachePolicy;
+    if (cachePolicy!=WMPageControllerCachePolicyDisable) {
+        self.memCache.countLimit = _cachePolicy;
+    }
 }
 
 - (void)setSelectIndex:(int)selectIndex {
@@ -556,10 +558,13 @@ static NSInteger const kWMControllerCountUndefined = -1;
     [self.displayVC removeObjectForKey:@(index)];
     
     // 放入缓存
-    if (![self.memCache objectForKey:@(index)]) {
-        [self willCachedController:viewController atIndex:index];
-        [self.memCache setObject:viewController forKey:@(index)];
+    if (self.cachePolicy!=WMPageControllerCachePolicyDisable) {
+        if (![self.memCache objectForKey:@(index)]) {
+            [self willCachedController:viewController atIndex:index];
+            [self.memCache setObject:viewController forKey:@(index)];
+        }
     }
+
 }
 
 - (void)wm_backToPositionIfNeeded:(UIViewController *)controller atIndex:(NSInteger)index {


### PR DESCRIPTION
如果子viewcontroller包含大量的数据逻辑，使用nscache会导致数据丢失，出现莫名其妙的错误，数据是否丢失的判断比较麻烦，还影响代码逻辑。

比较简单的策略就是在pagecontroller里禁止cache。并且**建议这个禁止缓存的策略是缺省**的。
