### PR TITLE
多参数传递

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ Here is an example:
 这是解决：这个tabVC创建的时候，需要多个参数，但是在别的地方传值的时候，不需要这么多个参数，可能是其中的一两个参数即可。如果要将其所有参数都用字典传值，就会导致所有要跳转的地方都改成字典传值。
 ```
     self.keys = @[@"paramDic", @"paramDic", @"paramDic"].mutableCopy; //这里key名字随便写的  
+    
     //这里生成tabVC的时候需要传两个值，但是在别的界面跳转过来只需要一个参数即可。这里这样写keys和Values，项目其他地方都不用修改
-    self.values = @[@{@"communityVcType":@(WChildCommunityVcTypeRecommend),@"isFromHomeLink":@(self.isFromHomeLink)}, @{@"communityVcType":@(WChildCommunityVcTypeFollowed),@"isFromHomeLink":@(self.isFromHomeLink)}, @{@"communityVcType":@(WChildCommunityVcTypeMine),@"isFromHomeLink":@(self.isFromHomeLink)}].mutableCopy;
+    
+    self.values = @[@{@"communityVcType":@(WChildCommunityVcTypeRecommend),@"isFromHomeLink":@(self.isFromHomeLink)},  @{@"communityVcType":@(WChildCommunityVcTypeFollowed),@"isFromHomeLink":@(self.isFromHomeLink)},  @{@"communityVcType":@(WChildCommunityVcTypeMine),@"isFromHomeLink":@(self.isFromHomeLink)}].mutableCopy;   
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -90,5 +90,14 @@ Here is an example:
 }
 ```
 
+## new i add 
+当子tabVC 需要多参数传递的时候，只需将参数封装成一个字典，但是这个字典属性不需要在子tabVC里添加，但是要里面的keys要对应添加属性
+这是解决：这个tabVC创建的时候，需要多个参数，但是在别的地方传值的时候，不需要这么多个参数，可能是其中的一两个参数即可。如果要将其所有参数都用字典传值，就会导致所有要跳转的地方都改成字典传值。
+```
+    self.keys = @[@"paramDic", @"paramDic", @"paramDic"].mutableCopy; //这里key名字随便写的  
+    //这里生成tabVC的时候需要传两个值，但是在别的界面跳转过来只需要一个参数即可。这里这样写keys和Values，项目其他地方都不用修改
+    self.values = @[@{@"communityVcType":@(WChildCommunityVcTypeRecommend),@"isFromHomeLink":@(self.isFromHomeLink)}, @{@"communityVcType":@(WChildCommunityVcTypeFollowed),@"isFromHomeLink":@(self.isFromHomeLink)}, @{@"communityVcType":@(WChildCommunityVcTypeMine),@"isFromHomeLink":@(self.isFromHomeLink)}].mutableCopy;
+```
+
 ## License
 This project is under MIT License. See LICENSE file for more information.

--- a/WMPageController/WMPageController.m
+++ b/WMPageController/WMPageController.m
@@ -551,7 +551,19 @@ static NSInteger const kWMControllerCountUndefined = -1;
     _initializedIndex = index;
     UIViewController *viewController = [self initializeViewControllerAtIndex:index];
     if (self.values.count == self.childControllersCount && self.keys.count == self.childControllersCount) {
-        [viewController setValue:self.values[index] forKey:self.keys[index]];
+        //这里将参数传值进行一下修改 扩展， 传多个参数封装成字典，然后遍历出参数 目前要传的参数只能封装成字典类型
+        //eg：这个tab界面 你需要两个参数，但是不能直接用字典传值，因为在别的界面跳转也有传值过去，可能只需要其中的一个参数就可以了，如果全改成字典，就要全局所有跳转的地方进行改动。
+        
+        id obj = self.values[index];
+        if( [obj isKindOfClass:[NSDictionary class]]){ //多个参数的操作
+            
+            NSDictionary * dic = (NSDictionary *)obj;
+            [dic enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
+                [viewController setValue:obj forKey:key];
+            }];
+        }else{  //单个参数的操作
+            [viewController setValue:self.values[index] forKey:self.keys[index]];
+        }
     }
     [self addChildViewController:viewController];
     CGRect frame = self.childViewFrames.count ? [self.childViewFrames[index] CGRectValue] : self.view.frame;


### PR DESCRIPTION
项目后期引入你的这个库。在生成顶部tabVC的时候，需要多参数，将其封装成一个字典，省去全局跳转这个顶部tabVC参数传递修改的麻烦。

在生成顶部tabVC的时候，需要多个参数，将其封装成字典传值。 但是在别的地方跳转到这个tabVC只需要一个参数。这时候这么处理，别的地方不用修改。