### PR TITLE
-initWithNibName: bundle: replaced -init and fix typo

### DIFF
--- a/WMPageController/WMPageController.m
+++ b/WMPageController/WMPageController.m
@@ -59,27 +59,8 @@ static NSInteger const kWMControllerCountUndefined = -1;
 }
 
 #pragma mark - Public Methods
-
-- (instancetype)initWithViewControllerClasses:(NSArray<Class> *)classes andTheirTitles:(NSArray<NSString *> *)titles {
-    if (self = [super init]) {
-        NSParameterAssert(classes.count == titles.count);
-        _viewControllerClasses = [NSArray arrayWithArray:classes];
-        _titles = [NSArray arrayWithArray:titles];
-
-        [self wm_setup];
-    }
-    return self;
-}
-
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     if (self = [super initWithCoder:aDecoder]) {
-        [self wm_setup];
-    }
-    return self;
-}
-
-- (instancetype)init {
-    if (self = [super init]) {
         [self wm_setup];
     }
     return self;
@@ -91,6 +72,16 @@ static NSInteger const kWMControllerCountUndefined = -1;
     }
     return self;
 }
+
+- (instancetype)initWithViewControllerClasses:(NSArray<Class> *)classes andTheirTitles:(NSArray<NSString *> *)titles {
+    if (self = [self initWithNibName:nil bundle:nil]) {
+        NSParameterAssert(classes.count == titles.count);
+        _viewControllerClasses = [NSArray arrayWithArray:classes];
+        _titles = [NSArray arrayWithArray:titles];
+    }
+    return self;
+}
+
 
 - (void)forceLayoutSubviews {
     if (!self.childControllersCount) return;

--- a/WMPageControllerDemo/StickyExample/StickyExample/WMStickyPageViewController/WMStickyPageViewController.h
+++ b/WMPageControllerDemo/StickyExample/StickyExample/WMStickyPageViewController/WMStickyPageViewController.h
@@ -44,4 +44,6 @@
  */
 @property (nonatomic, readonly) CGFloat maximumContentOffsetY;
 
+
+- (void)updateStreachScrollViewIfNeeded;
 @end

--- a/WMPageControllerDemo/StickyExample/StickyExample/WMStickyPageViewController/WMStickyPageViewController.m
+++ b/WMPageControllerDemo/StickyExample/StickyExample/WMStickyPageViewController/WMStickyPageViewController.m
@@ -78,9 +78,7 @@
             delegate = (id<UIScrollViewDelegate>)self.matrioska;
         }
         
-        if (![NSStringFromClass([beforeDelegate class]) isEqualToString:matrioskaClassName]) {
-            [self MultipleDelegate_setDelegate:delegate];
-        }
+        [self MultipleDelegate_setDelegate:delegate];
     }
     
 }
@@ -89,17 +87,17 @@
 - (void)addMethodIfNecessaryWithTarget:(id)target {
     SEL sel = @selector(scrollViewDidScroll:);
     if (![target respondsToSelector:sel]) {
-        class_addMethod([target class], sel, (IMP)_emptyMethod, "v@:");
+        class_addMethod([target class], sel, (IMP)_emptyMethod, "v@:@");
     }
     
     sel = @selector(scrollViewWillEndDragging:withVelocity:targetContentOffset:);
     if (![target respondsToSelector:sel]) {
-        class_addMethod([target class], sel, (IMP)_emptyMethod1, "v@:dd*");
+        class_addMethod([target class], sel, (IMP)_emptyMethod1, "v@:@dd*");
     }
     
     sel = @selector(scrollViewWillBeginDragging:);
     if (![target respondsToSelector:sel]) {
-        class_addMethod([target class], sel, (IMP)_emptyMethod, "v@:");
+        class_addMethod([target class], sel, (IMP)_emptyMethod, "v@:@");
     }
     
 }
@@ -186,9 +184,7 @@ void _emptyMethod1(id current_self, SEL current_cmd, UIScrollView *scrollView, C
 
 #pragma mark - notification
 - (void)didFullyDisplayedNotification {
-    UIViewController *currentViewController = self.currentViewController;
-    UIScrollView *scrollView = [self streachScrollViewFromViewController:currentViewController];
-    scrollView.delegate = self;
+    [self configureStreachScrollViewDelegate];
 }
 
 
@@ -209,6 +205,11 @@ void _emptyMethod1(id current_self, SEL current_cmd, UIScrollView *scrollView, C
             }
         }
     }
+}
+
+#pragma mark - public
+- (void)updateStreachScrollViewIfNeeded {
+    [self configureStreachScrollViewDelegate];
 }
 
 
@@ -335,10 +336,11 @@ void _emptyMethod1(id current_self, SEL current_cmd, UIScrollView *scrollView, C
 }
 
 #pragma mark - utilities
-- (CGFloat)maximumContentOffsetY {
-    return floor(self.headerViewHeight - self.minimumTopInset);
+- (void)configureStreachScrollViewDelegate {
+    UIViewController *currentViewController = self.currentViewController;
+    UIScrollView *scrollView = [self streachScrollViewFromViewController:currentViewController];
+    scrollView.delegate = self;
 }
-
 
 - (UIScrollView *)streachScrollViewFromViewController:(UIViewController *)viewController {
     if ([self hasStreachScrollViewWithViewController:viewController]) {
@@ -359,5 +361,8 @@ void _emptyMethod1(id current_self, SEL current_cmd, UIScrollView *scrollView, C
 }
 
 
+- (CGFloat)maximumContentOffsetY {
+    return floor(self.headerViewHeight - self.minimumTopInset);
+}
 
 @end


### PR DESCRIPTION
If you call init, actually it will be call -initWithNibName: bundle:
and specify nil for both of this methods arguments.