### PR TITLE
修复由于进行除0操作所造成的闪退

### DIFF
--- a/WMPageControllerDemo/StickyExample/StickyExample/WMStickyPageViewController/TPDelegateMatrioska/TPDelegateMatrioska.h
+++ b/WMPageControllerDemo/StickyExample/StickyExample/WMStickyPageViewController/TPDelegateMatrioska/TPDelegateMatrioska.h
@@ -17,9 +17,9 @@
 
 @property (readonly, nonatomic, strong) NSArray *delegates;
 
-- (instancetype)initWithQOS:(NSQualityOfService)qos;
+- (instancetype)initWithDelegateQueueQOS:(NSQualityOfService)qos;
 
-- (instancetype)initWithDelegates:(NSArray *)delegates qos:(NSQualityOfService)qos;
+- (instancetype)initWithDelegates:(NSArray *)delegates delegateQueueQOS:(NSQualityOfService)qos;
 
 - (instancetype)initWithDelegates:(NSArray *)delegates;
 

--- a/WMPageControllerDemo/StickyExample/StickyExample/WMStickyPageViewController/TPDelegateMatrioska/TPDelegateMatrioska.m
+++ b/WMPageControllerDemo/StickyExample/StickyExample/WMStickyPageViewController/TPDelegateMatrioska/TPDelegateMatrioska.m
@@ -39,7 +39,7 @@ static inline qos_class_t NSQualityOfServiceToQOSClass(NSQualityOfService qos) {
 
 @implementation TPDelegateMatrioska
 
-- (instancetype)initWithQOS:(NSQualityOfService)qos {
+- (instancetype)initWithDelegateQueueQOS:(NSQualityOfService)qos {
     _mutableDelegates = [NSPointerArray weakObjectsPointerArray];
     dispatch_qos_class_t qosClass = NSQualityOfServiceToQOSClass(qos);
     dispatch_queue_attr_t attr = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, qosClass, 0);
@@ -47,8 +47,8 @@ static inline qos_class_t NSQualityOfServiceToQOSClass(NSQualityOfService qos) {
     return self;
 }
 
-- (instancetype)initWithDelegates:(NSArray *)delegates qos:(NSQualityOfService)qos {
-    self = [self initWithQOS:qos];
+- (instancetype)initWithDelegates:(NSArray *)delegates delegateQueueQOS:(NSQualityOfService)qos {
+    self = [self initWithDelegateQueueQOS:qos];
     [delegates enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         [_mutableDelegates addPointer:(void *)obj];
     }];
@@ -56,7 +56,7 @@ static inline qos_class_t NSQualityOfServiceToQOSClass(NSQualityOfService qos) {
 }
 
 - (instancetype)initWithDelegates:(NSArray *)delegates {
-    return [self initWithDelegates:delegates qos:NSQualityOfServiceDefault];
+    return [self initWithDelegates:delegates delegateQueueQOS:NSQualityOfServiceDefault];
 }
 
 

--- a/WMPageControllerDemo/StickyExample/StickyExample/WMStickyPageViewController/WMStickyPageViewController.m
+++ b/WMPageControllerDemo/StickyExample/StickyExample/WMStickyPageViewController/WMStickyPageViewController.m
@@ -90,7 +90,11 @@
     
     sel = @selector(scrollViewWillEndDragging:withVelocity:targetContentOffset:);
     if (![target respondsToSelector:sel]) {
+#if CGFLOAT_IS_DOUBLE
         class_addMethod([target class], sel, (IMP)_emptyMethod1, "v@:@dd*");
+#else
+        class_addMethod([target class], sel, (IMP)_emptyMethod1, "v@:@ff*");
+#endif
     }
     
     sel = @selector(scrollViewWillBeginDragging:);
@@ -277,6 +281,7 @@ void _emptyMethod1(id current_self, SEL current_cmd, UIScrollView *scrollView, C
 
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset {
     [super scrollViewWillEndDragging:scrollView withVelocity:velocity targetContentOffset:targetContentOffset];
+    NSLog(@"CGPoint: %@", NSStringFromCGPoint(velocity));
     if (scrollView != [self streachScrollViewFromViewController:self.currentViewController]) {
         return;
     }

--- a/WMPageControllerDemo/StickyExample/StickyExample/WMStickyPageViewController/WMStickyPageViewController.m
+++ b/WMPageControllerDemo/StickyExample/StickyExample/WMStickyPageViewController/WMStickyPageViewController.m
@@ -65,7 +65,7 @@
     }else {
         if ([originDelegate conformsToProtocol:@protocol(WMStickyPageViewControllerDelegate)]) {
             if (!self.matrioska) {
-                self.matrioska = [[TPDelegateMatrioska alloc] initWithQOS:NSQualityOfServiceUserInitiated];
+                self.matrioska = [[TPDelegateMatrioska alloc] initWithDelegateQueueQOS:NSQualityOfServiceUserInitiated];
             }
             
             if (originDelegate) {
@@ -286,11 +286,16 @@ void _emptyMethod1(id current_self, SEL current_cmd, UIScrollView *scrollView, C
         return;
     }
     
+    if (velocity.y == 0) {
+        return;
+    }
+    
     [self.animator removeAllBehaviors];
     WMStickyPageViewControllerDynamicItem *item = [WMStickyPageViewControllerDynamicItem new];
     item.center = self.basicScrollView.contentOffset;
     UIDynamicItemBehavior *inertialBehavior = [[UIDynamicItemBehavior alloc] initWithItems:@[item]];
-    [inertialBehavior addLinearVelocity:CGPointMake(0, velocity.y / fabs(velocity.y)  * 400) forItem:item];
+    CGFloat dynamicItemVelocityY = velocity.y > 0 ? 400 : -400;
+    [inertialBehavior addLinearVelocity:CGPointMake(0, dynamicItemVelocityY) forItem:item];
     inertialBehavior.resistance = 1;
     __weak __typeof(self) weak_self = self;
     inertialBehavior.action = ^(){
@@ -305,7 +310,9 @@ void _emptyMethod1(id current_self, SEL current_cmd, UIScrollView *scrollView, C
             contentOffsetY = 0;
         }
         
-        self.basicScrollView.contentOffset = CGPointMake(0, contentOffsetY);
+        if (!isnan(contentOffsetY)) {
+            self.basicScrollView.contentOffset = CGPointMake(0, contentOffsetY);
+        }
     };
     [self.animator addBehavior:inertialBehavior];
 }


### PR DESCRIPTION
在线上项目中发现了大量的类似这样的 `bug`：
> CALayer bounds contains NaN: [0 nan; 375 667]

经查是由于不小心进行了除0操作所导致。