### PR TITLE
1.WMPageController新增属性 WMScrollView重写一个方法hitTest 用来处理 左右滑动的冲突

### DIFF
--- a/WMPageController/WMMenuView/WMScrollView.h
+++ b/WMPageController/WMMenuView/WMScrollView.h
@@ -10,4 +10,6 @@
 
 @interface WMScrollView : UIScrollView <UIGestureRecognizerDelegate>
 
+@property (nonatomic, weak) Class scrollEnableIgnoreClass;
+
 @end

--- a/WMPageController/WMMenuView/WMScrollView.m
+++ b/WMPageController/WMMenuView/WMScrollView.m
@@ -20,4 +20,23 @@
     return NO;
 }
 
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+    UIView *result = [super hitTest:point withEvent:event];
+    
+    if(self.scrollEnableIgnoreClass != nil)
+    {
+        if([result isKindOfClass:[self.scrollEnableIgnoreClass class]])
+        {
+            self.scrollEnabled = NO;
+        }
+        else
+        {
+            self.scrollEnabled = YES;
+        }
+    }
+
+    return result ;
+}
+
 @end

--- a/WMPageController/WMPageController.h
+++ b/WMPageController/WMPageController.h
@@ -176,6 +176,10 @@ extern NSString *const WMControllerDidFullyDisplayedNotification;
 /** Whether the controller can scroll. Default is YES. */
 @property (nonatomic, assign) BOOL scrollEnable;
 
+//scrollEnable 为YES下 左右滑动会和一些类冲突
+//可以设置scrollEnableIgnoreClass暂时禁用scrollEnable
+@property (nonatomic, copy) Class scrollEnableIgnoreClass;
+
 /**
  *  选中时的标题尺寸
  *  The title size when selected (animatable)

--- a/WMPageController/WMPageController.m
+++ b/WMPageController/WMPageController.m
@@ -104,6 +104,13 @@ static NSInteger const kWMControllerCountUndefined = -1;
     self.scrollView.scrollEnabled = scrollEnable;
 }
 
+- (void)setScrollEnableIgnoreClass:(Class)scrollEnableIgnoreClass {
+    _scrollEnableIgnoreClass = scrollEnableIgnoreClass;
+
+    if (!self.scrollView) return;
+    self.scrollView.scrollEnableIgnoreClass = scrollEnableIgnoreClass;
+}
+
 - (void)setProgressViewCornerRadius:(CGFloat)progressViewCornerRadius {
     _progressViewCornerRadius = progressViewCornerRadius;
     if (self.menuView) {
@@ -400,6 +407,7 @@ static NSInteger const kWMControllerCountUndefined = -1;
     _markedSelectIndex = kWMUndefinedIndex;
     _controllerCount  = kWMControllerCountUndefined;
     _scrollEnable = YES;
+    _scrollEnableIgnoreClass = nil;
     _progressViewCornerRadius = WMUNDEFINED_VALUE;
     _progressHeight = WMUNDEFINED_VALUE;
     
@@ -436,6 +444,7 @@ static NSInteger const kWMControllerCountUndefined = -1;
     scrollView.showsHorizontalScrollIndicator = NO;
     scrollView.bounces = self.bounces;
     scrollView.scrollEnabled = self.scrollEnable;
+    scrollView.scrollEnableIgnoreClass = self.scrollEnableIgnoreClass;
     if (@available(iOS 11.0, *)) {
         scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
     }


### PR DESCRIPTION
左右滑动 手势冲突
WMPageController 在允许左右滑动下 如果子页面 如果有手势控件比如Slider 会冲突
给WMPageController新增了一个属性 scrollEnableIgnoreClass 保留需要优先的手势控件
WMScrollView 在 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event 里面进行判断 