### PR TITLE
添加全屏返回手势的支持

### DIFF
--- a/WMPageController/WMMenuView/WMScrollView+ScrollBack.h
+++ b/WMPageController/WMMenuView/WMScrollView+ScrollBack.h
@@ -1,0 +1,17 @@
+//
+//  WMScrollView+ScrollBack.h
+//  KXLive
+//
+//  Created by 林祖涵 on 2018/11/29.
+//  Copyright © 2018 ibobei. All rights reserved.
+//
+
+#import "WMScrollView.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WMScrollView (ScrollBack)
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WMPageController/WMMenuView/WMScrollView+ScrollBack.m
+++ b/WMPageController/WMMenuView/WMScrollView+ScrollBack.m
@@ -1,0 +1,32 @@
+//
+//  WMScrollView+ScrollBack.m
+//  KXLive
+//
+//  Created by 林祖涵 on 2018/11/29.
+//  Copyright © 2018 ibobei. All rights reserved.
+//
+
+#import "WMScrollView+ScrollBack.h"
+
+@implementation WMScrollView (ScrollBack)
+
+#pragma mark - <UIGestureRecognizerDelegate>
+
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
+{
+    if ([gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) {
+        UIPanGestureRecognizer *tmpGesture = (UIPanGestureRecognizer *)gestureRecognizer;
+        CGPoint translation = [tmpGesture translationInView:tmpGesture.view];
+        /* 当scrollView滑到初始位置时，再滑动就让返回手势生效
+         * translation.x > 0 表示向右滑动 translation.x <= 0 表示向左滑动
+         */
+        if (self.contentOffset.x <= 0
+            && translation.x > 0) {
+            return NO;
+        }
+    }
+    
+    return YES;
+}
+
+@end


### PR DESCRIPTION
当使用自定义全屏手势返回的时候，会出现集成了WMPageController的页面，无法响应返回手势，所以添加此分类，以实现全屏手势返回