### PR TITLE
fix:增加setProgressColor，setMenuViewStyle方法

### DIFF
--- a/WMPageController/WMPageController.m
+++ b/WMPageController/WMPageController.m
@@ -166,6 +166,20 @@ static NSInteger const kWMControllerCountUndefined = -1;
     }
 }
 
+- (void)setProgressColor:(UIColor *)progressColor {
+    _progressColor = progressColor;
+    if (self.menuView) {
+        self.menuView.lineColor = progressColor;
+    }
+}
+
+- (void)setMenuViewStyle:(WMMenuViewStyle)menuViewStyle {
+    _menuViewStyle = menuViewStyle;
+    if (self.menuView) {
+        self.menuView.style = menuViewStyle;
+    }
+}
+
 - (void)setMenuViewContentMargin:(CGFloat)menuViewContentMargin {
     _menuViewContentMargin = menuViewContentMargin;
     if (self.menuView) {


### PR DESCRIPTION
您好，感谢作者开源WMPageController库。在使用时，*** self.progressColor = UIColor.whiteColor *** 或者 *** self.menuViewStyle = WMMenuViewStyleLine *** 时，我发现设置ProgressColor，MenuViewStyle后无效。